### PR TITLE
Allow encode(rect, "png")-style calls

### DIFF
--- a/openfl/_legacy/display/BitmapData.hx
+++ b/openfl/_legacy/display/BitmapData.hx
@@ -194,6 +194,10 @@ class BitmapData implements IBitmapDrawable {
 				
 				return byteArray = lime_bitmap_data_encode (__handle, "jpg", cast (compressorOrQuality, JPEGEncoderOptions).quality / 100);
 				
+			} else if (Std.is (compressorOrQuality, String)) {
+				
+				return byteArray = lime_bitmap_data_encode (__handle, compressorOrQuality, 1);
+				
 			}
 			
 			return byteArray = null;


### PR DESCRIPTION
The FlxScreenGrab of HaxeFlixel depends on this.  It doesn't let you pass in a quality, so quality 1 is assumed, but at least it works instead of just returning null, on HaxeFlixel's current default of using OpenFL legacy.  (That's why I left the compatibility comment in there--not sure how it was planned to add that in, without adding an optional parameter, which seems to work well in general except on flash, where it would be a breaking change.  So: partial compatibility without the breaking-change cost.)